### PR TITLE
List and remember collections from root

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,5 +2,37 @@
   "name": "stac-repl",
   "lockfileVersion": 2,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "dependencies": {
+        "@turf/helpers": "^6.3.0",
+        "xhr2": "^0.2.1"
+      }
+    },
+    "node_modules/@turf/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+    },
+    "node_modules/xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  },
+  "dependencies": {
+    "@turf/helpers": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.3.0.tgz",
+      "integrity": "sha512-kr6KuD4Z0GZ30tblTEvi90rvvVNlKieXuMC8CTzE/rVQb0/f/Cb29zCXxTD7giQTEQY/P2nRW23wEqqyNHulCg=="
+    },
+    "xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw=="
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,1 +1,6 @@
-{}
+{
+  "dependencies": {
+    "@turf/helpers": "^6.3.0",
+    "xhr2": "^0.2.1"
+  }
+}

--- a/spago.dhall
+++ b/spago.dhall
@@ -10,6 +10,7 @@ You can edit this file as you like.
   , "node-readline"
   , "parsing"
   , "psci-support"
+  , "stac"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,7 +4,8 @@ You can edit this file as you like.
 -}
 { name = "my-project"
 , dependencies =
-  [ "console"
+  [ "ansi"
+  , "console"
   , "effect"
   , "monad-control"
   , "node-readline"

--- a/src/Command.purs
+++ b/src/Command.purs
@@ -1,0 +1,48 @@
+module Command where
+
+import Control.Alt ((<|>))
+import Control.Apply ((*>), (<$))
+import Data.List (List, toUnfoldable)
+import Data.Maybe (Maybe(..))
+import Data.String.CodeUnits (fromCharArray)
+import Data.String.NonEmpty (fromString)
+import Prelude (pure, (<$>), (<<<), (>>=))
+import Text.Parsing.Parser (fail)
+import Text.Parsing.Parser.Combinators (manyTill)
+import Text.Parsing.Parser.String (anyChar, eof, skipSpaces, string)
+import Types (Cmd(..), Context(..), StringParser)
+
+fromList :: forall a. List a -> Array a
+fromList = toUnfoldable
+
+collectionIdParser :: StringParser String
+collectionIdParser = fromCharArray <<< fromList <$> (string "set collection" *> skipSpaces *> manyTill anyChar eof)
+
+setCollectionParser :: StringParser Cmd
+setCollectionParser =
+  SetCollection
+    <$> ( collectionIdParser
+          >>= \s -> case fromString s of
+              Just ne -> pure ne
+              Nothing -> fail "Cannot set an empty string as collection"
+      )
+
+setRootUrlParser :: StringParser Cmd
+setRootUrlParser = SetRootUrl <<< fromCharArray <<< fromList <$> (string "set root url" *> skipSpaces *> manyTill anyChar eof)
+
+locateCollectionParser :: StringParser Cmd
+locateCollectionParser = LocateCollection <$ (string "locate" *> skipSpaces *> eof)
+
+listCollectionsParser :: StringParser Cmd
+listCollectionsParser = ListCollections <$ (string "list collections" *> skipSpaces *> manyTill anyChar eof)
+
+getParser :: Context -> StringParser Cmd
+getParser ctx = case ctx of
+  RootContext _ -> setCollectionParser <|> setRootUrlParser <|> listCollectionsParser
+  CollectionContext { collectionId } ->
+    ViewCollection collectionId <$ (string "view" *> skipSpaces *> eof)
+      <|> UnsetCollection
+      <$ (string "unset collection" *> skipSpaces *> eof)
+      <|> setCollectionParser
+      <|> setRootUrlParser
+      <|> locateCollectionParser

--- a/src/Completions.purs
+++ b/src/Completions.purs
@@ -1,0 +1,43 @@
+module Completions where
+
+import Command (collectionIdParser)
+import Data.Array (filter)
+import Data.Either (fromRight)
+import Data.Set (toUnfoldable)
+import Data.String (Pattern(..), contains)
+import Effect (Effect)
+import Effect.Ref (Ref, read)
+import Prelude (bind, pure, ($), (<$>), (<>))
+import Text.Parsing.Parser (runParser)
+import Types (Context(..))
+
+getCompletions :: Ref Context -> String -> Effect ({ matched :: String, completions :: Array String })
+getCompletions ctxRef s = do
+  ctx <- read ctxRef
+  contextCompleter ctx $ s
+
+collectionCommands :: Array String
+collectionCommands = [ "view", "unset collection", "locate" ]
+
+rootCommands :: Array String
+rootCommands = [ "set root url", "set collection", "list collections" ]
+
+contextCompleter :: Context -> (String -> Effect { matched :: String, completions :: Array String })
+contextCompleter (RootContext { knownCollections }) = \s ->
+  let
+    strInCommand = filter (\cmd -> contains (Pattern s) cmd) rootCommands
+
+    collectionIdParseResult = runParser s collectionIdParser
+
+    collectionIdMatches =
+      fromRight []
+        $ (\collectionId -> filter (\known -> contains (Pattern collectionId) known) (toUnfoldable knownCollections))
+        <$> collectionIdParseResult
+  in
+    pure $ { matched: s, completions: strInCommand <> collectionIdMatches }
+
+contextCompleter (CollectionContext _) = \s ->
+  let
+    strInCommand = filter (\cmd -> contains (Pattern s) cmd) collectionCommands
+  in
+    pure $ { matched: s, completions: strInCommand }

--- a/src/Context.purs
+++ b/src/Context.purs
@@ -1,0 +1,21 @@
+module Context where
+
+import Data.Maybe (Maybe(..))
+import Types (CollectionContextRecord, Context(..), RootUrl, RootContextRecord)
+
+toCollectionContext :: Context -> Maybe CollectionContextRecord
+toCollectionContext (CollectionContext rec) = Just rec
+
+toCollectionContext _ = Nothing
+
+toRootUrl :: Context -> Maybe RootUrl
+toRootUrl (RootContext { rootUrl: Just u }) = Just u
+
+toRootUrl (CollectionContext { rootUrl }) = Just rootUrl
+
+toRootUrl _ = Nothing
+
+toRootContext :: Context -> Maybe RootContextRecord
+toRootContext (RootContext rec) = Just rec
+
+toRootContext _ = Nothing

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -1,0 +1,17 @@
+module Printer where
+
+import Ansi.Codes (Color(..))
+import Ansi.Output (foreground, withGraphics)
+import Data.Functor (void)
+import Data.Stac (Collection(..), CollectionsResponse(..))
+import Data.Traversable (traverse)
+import Effect.Class (class MonadEffect)
+import Effect.Class.Console (log)
+import Prelude (Unit, ($), (<<<), (<>))
+
+prettyPrintCollections :: forall m. MonadEffect m => CollectionsResponse -> m Unit
+prettyPrintCollections (CollectionsResponse { collections }) =
+  let
+    collectionLine (Collection collection) = withGraphics (foreground Blue) (collection.id <> ": ") <> collection.description <> "\n"
+  in
+    void $ traverse (log <<< collectionLine) collections

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -1,0 +1,42 @@
+module Types where
+
+import Data.Generic.Rep (class Generic)
+import Data.Maybe (Maybe)
+import Data.Set (Set)
+import Data.Show.Generic (genericShow)
+import Data.String.NonEmpty (NonEmptyString)
+import Prelude (class Show)
+import Text.Parsing.Parser (Parser)
+
+type RootUrl
+  = String
+
+type CollectionId
+  = String
+
+type CollectionContextRecord
+  = { rootUrl :: RootUrl, collectionId :: NonEmptyString }
+
+type RootContextRecord
+  = { rootUrl :: Maybe RootUrl, knownCollections :: Set CollectionId }
+
+data Context
+  = RootContext RootContextRecord
+  | CollectionContext CollectionContextRecord
+
+derive instance genericContext :: Generic Context _
+
+instance showContext :: Show Context where
+  show = genericShow
+
+data Cmd
+  = GetCollection NonEmptyString
+  | SetCollection NonEmptyString
+  | ListCollections
+  | ViewCollection NonEmptyString
+  | LocateCollection
+  | SetRootUrl RootUrl
+  | UnsetCollection
+
+type StringParser
+  = Parser String


### PR DESCRIPTION
Overview
-----

This PR adds a command to `list collections` from the root context, provided you've set a root url.

Demo
-----

```
stac > set root url https://api.radiant.earth/mlhub/v1
stac https://api.radiant.earth/mlhub/v1 > list collections
stac https://api.radiant.earth/mlhub/v1 > ref_african_crops_kenya_01_labels: African Crops Kenya

ref_african_crops_kenya_01_source: African Crops Kenya Source Imagery

ref_african_crops_tanzania_01_labels: African Crops Tanzania

ref_african_crops_tanzania_01_source: African Crops Tanzania Source Imagery

ref_african_crops_uganda_01_labels: African Crops Uganda

ref_african_crops_uganda_01_source: African Crops Uganda Source Imagery

microsoft_chesapeake_landsat_leaf_off: Microsoft Chesapeake Landsat 8 Leaf-Off Composite

microsoft_chesapeake_buildings: Microsoft Chesapeake Buildings

sn4_AOI_6_Atlanta: SpaceNet 4 Atlanta Chipped Training Dataset

...

stac https://api.radiant.earth/mlhub/v1 > set collection sen12flood
sen12floods_s1_labels  sen12floods_s1_source  sen12floods_s2_labels  sen12floods_s2_source

stac https://api.radiant.earth/mlhub/v1 > set collection sen12flood
```

## Notes

For some reason, even when only one item is in the matches array... it refuses to complete the whole collection id for you. That's annoying, but not a showstopper, and something I can figure out later.

Closes #1 