### PR TITLE
Add command to fetch conformance

### DIFF
--- a/src/Command.purs
+++ b/src/Command.purs
@@ -43,10 +43,11 @@ getParser :: Context -> StringParser Cmd
 getParser ctx = case ctx of
   RootContext { rootUrl: Nothing } -> setCollectionParser <|> setRootUrlParser <|> listCollectionsParser
   RootContext { rootUrl: Just url } -> setCollectionParser <|> setRootUrlParser <|> listCollectionsParser <|> getConformanceParser url
-  CollectionContext { collectionId } ->
+  CollectionContext { collectionId, rootUrl } ->
     ViewCollection collectionId <$ (string "view" *> skipSpaces *> eof)
       <|> UnsetCollection
       <$ (string "unset collection" *> skipSpaces *> eof)
       <|> setCollectionParser
       <|> setRootUrlParser
       <|> locateCollectionParser
+      <|> getConformanceParser rootUrl

--- a/src/Completions.purs
+++ b/src/Completions.purs
@@ -19,7 +19,7 @@ getCompletions ctxRef s = do
   contextCompleter ctx $ s
 
 collectionCommands :: Array String
-collectionCommands = [ "view", "unset collection", "locate" ]
+collectionCommands = [ "view", "unset collection", "locate", "get conformance" ]
 
 rootCommands :: Maybe RootUrl -> Array String
 rootCommands rootUrlM =

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -3,11 +3,11 @@ module Printer where
 import Ansi.Codes (Color(..))
 import Ansi.Output (foreground, withGraphics)
 import Data.Functor (void)
-import Data.Stac (Collection(..), CollectionsResponse(..))
+import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses)
 import Data.Traversable (traverse)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (log)
-import Prelude (Unit, ($), (<<<), (<>))
+import Prelude (Unit, discard, ($), (<<<), (<>))
 
 prettyPrintCollections :: forall m. MonadEffect m => CollectionsResponse -> m Unit
 prettyPrintCollections (CollectionsResponse { collections }) =
@@ -15,3 +15,8 @@ prettyPrintCollections (CollectionsResponse { collections }) =
     collectionLine (Collection collection) = withGraphics (foreground Blue) (collection.id <> ": ") <> collection.description <> "\n"
   in
     void $ traverse (log <<< collectionLine) collections
+
+prettyPrintConformance :: forall m. MonadEffect m => ConformanceClasses -> m Unit
+prettyPrintConformance { conformsTo } = do
+  log $ withGraphics (foreground Blue) "Conforms to:\n"
+  void $ traverse log conformsTo

--- a/src/Repl.purs
+++ b/src/Repl.purs
@@ -20,7 +20,7 @@ import Effect.Ref (Ref, modify_, new, read)
 import Node.ReadLine (Interface, createConsoleInterface, prompt, setLineHandler, setPrompt)
 import Prelude (Unit, bind, discard, pure, show, ($), (*>), (<$>), (<<<), (<>), (>>=))
 import Printer (prettyPrintCollections, prettyPrintConformance)
-import Text.Parsing.Parser (parseErrorMessage, runParser)
+import Text.Parsing.Parser (runParser)
 import Types (Cmd(..), Context(..))
 
 updateKnownCollections :: forall m. MonadEffect m => Ref Context -> Array Collection -> m Unit
@@ -134,7 +134,12 @@ lineHandler ctxRef interface s = do
     cmdParseResult = runParser s parser
   case Tuple s cmdParseResult of
     Tuple "" _ -> prompt interface
-    Tuple _ (Left parseError) -> log $ parseErrorMessage parseError
+    Tuple _ (Left _) -> do
+      log
+        $ "I didn't recognize the command "
+        <> s
+        <> ". Try <TAB><TAB> to see available commands."
+      prompt interface
     Tuple _ (Right cmd) -> execute interface ctxRef cmd
 
 replProgram :: Effect Interface

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -32,6 +32,7 @@ instance showContext :: Show Context where
 data Cmd
   = GetCollection NonEmptyString
   | SetCollection NonEmptyString
+  | GetConformance RootUrl
   | ListCollections
   | ViewCollection NonEmptyString
   | LocateCollection


### PR DESCRIPTION
```
stac > set root url https://franklin.nasa-hsi.azavea.com
stac https://franklin.nasa-hsi.azavea.com > get conformance
stac https://franklin.nasa-hsi.azavea.com > Conforms to:


http://www.opengis.net/spec/ogcapi-features-1/1.0/req/core
http://www.opengis.net/spec/ogcapi-features-1/1.0/req/oas30
http://www.opengis.net/spec/ogcapi-features-1/1.0/req/geojson
```

`get conformance` isn't available in tab completions from root unless you have a root url set. It's always available in tab completions from collection.

also, for command errors:

```
stac > asdf
I didn't recognize the command asdf. Try <TAB><TAB> to see available commands.
```

Closes #3 