### PR TITLE
Improve tab completion, errors, collection view

### DIFF
--- a/src/Command.purs
+++ b/src/Command.purs
@@ -42,7 +42,11 @@ getConformanceParser root = GetConformance root <$ (string "get conformance" *> 
 getParser :: Context -> StringParser Cmd
 getParser ctx = case ctx of
   RootContext { rootUrl: Nothing } -> setRootUrlParser
-  RootContext { rootUrl: Just url } -> setCollectionParser <|> setRootUrlParser <|> listCollectionsParser <|> getConformanceParser url
+  RootContext { rootUrl: Just url } ->
+    setCollectionParser
+      <|> setRootUrlParser
+      <|> listCollectionsParser
+      <|> getConformanceParser url
   CollectionContext { collectionId, rootUrl } ->
     ViewCollection collectionId <$ (string "view" *> skipSpaces *> eof)
       <|> UnsetCollection

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -1,4 +1,9 @@
-module Printer where
+module Printer
+  ( colorizeError
+  , prettyPrintCollections
+  , prettyPrintCollection
+  , prettyPrintConformance
+  ) where
 
 import Ansi.Codes (Color(..))
 import Ansi.Output (foreground, withGraphics)
@@ -7,7 +12,10 @@ import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses)
 import Data.Traversable (traverse)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (log)
-import Prelude (Unit, discard, ($), (<<<), (<>))
+import Prelude (class Show, Unit, discard, show, ($), (<<<), (<>))
+
+prettyPrintKVPair :: forall a. Show a => String -> a -> String
+prettyPrintKVPair key value = (withGraphics (foreground Blue) key) <> ": " <> show value
 
 prettyPrintCollections :: forall m. MonadEffect m => CollectionsResponse -> m Unit
 prettyPrintCollections (CollectionsResponse { collections }) =
@@ -20,3 +28,14 @@ prettyPrintConformance :: forall m. MonadEffect m => ConformanceClasses -> m Uni
 prettyPrintConformance { conformsTo } = do
   log $ withGraphics (foreground Blue) "Conforms to:\n"
   void $ traverse log conformsTo
+
+prettyPrintCollection :: forall m. MonadEffect m => Collection -> m Unit
+prettyPrintCollection (Collection record) = do
+  log $ (withGraphics (foreground Blue) "Got collection ") <> record.id
+  log $ "Here's some information about it."
+  log $ prettyPrintKVPair "License" record.license
+  log $ prettyPrintKVPair "Temporal extent" record.extent.temporal
+  log $ prettyPrintKVPair "Spatial extent" record.extent.spatial
+
+colorizeError :: String -> String
+colorizeError = withGraphics (foreground Red)

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -15,7 +15,7 @@ type CollectionId
   = String
 
 type CollectionContextRecord
-  = { rootUrl :: RootUrl, collectionId :: NonEmptyString }
+  = { rootUrl :: RootUrl, collectionId :: NonEmptyString, knownCollections :: Set CollectionId }
 
 type RootContextRecord
   = { rootUrl :: Maybe RootUrl, knownCollections :: Set CollectionId }
@@ -30,8 +30,7 @@ instance showContext :: Show Context where
   show = genericShow
 
 data Cmd
-  = GetCollection NonEmptyString
-  | SetCollection NonEmptyString
+  = SetCollection NonEmptyString
   | GetConformance RootUrl
   | ListCollections
   | ViewCollection NonEmptyString


### PR DESCRIPTION
This PR:

- makes it so the `view` command in the collection context does something useful instead of lying about getting the collection by id
- makes errors red
- fixes the tab completion so that the completer actually fills in the part of the id that you match for you