### PR TITLE
List and page through items from collection context

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,7 @@ Brief description of what this PR does, and why it is needed.
 
 ### Checklist
 
-- [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))
-- [ ] Anything JSON-related has a round trip test
+* [ ] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))
 
 ### Demo
 
@@ -17,8 +16,8 @@ Optional. Ancillary topics, caveats, alternative strategies that didn't work out
 
 ## Testing Instructions
 
-- How to test this PR
-- Prefer bulleted description
-- For any testint instructions that aren't covered by automated tests
+* How to test this PR
+* Prefer bulleted description
+* For any testint instructions that aren't covered by automated tests
 
 Closes #XXX

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- List and page through items from collection context [#11](https://github.com/jisantuc/stac-repl/pull/11) (@jisantuc)

--- a/packages.dhall
+++ b/packages.dhall
@@ -105,7 +105,7 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210302/packages.dhall sha256:20cc5b89cf15433623ad6f250f112bf7a6bd82b5972363ecff4abf1febb02c50
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210318/packages.dhall sha256:98bbacd65191cef354ecbafa1610be13e183ee130491ab9c0ef6e3d606f781b5
 
 in  upstream
   with stac =

--- a/src/Completions.purs
+++ b/src/Completions.purs
@@ -19,7 +19,7 @@ getCompletions ctxRef s = do
   contextCompleter ctx $ s
 
 collectionCommands :: Array String
-collectionCommands = [ "view", "unset collection", "locate", "get conformance" ]
+collectionCommands = [ "view", "unset collection", "locate", "get conformance", "list items", "next page" ]
 
 rootCommands :: Maybe RootUrl -> Array String
 rootCommands rootUrlM =

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -3,16 +3,21 @@ module Printer
   , prettyPrintCollections
   , prettyPrintCollection
   , prettyPrintConformance
+  , prettyPrintItems
   ) where
 
 import Ansi.Codes (Color(..))
 import Ansi.Output (foreground, withGraphics)
+import Data.Array.NonEmpty (fromArray)
 import Data.Functor (void)
-import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses)
-import Data.Traversable (traverse)
+import Data.Maybe (Maybe(..), fromMaybe)
+import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses, Item(..), ItemAsset(..))
+import Data.Traversable (fold, traverse)
+import Data.TraversableWithIndex (traverseWithIndex)
 import Effect.Class (class MonadEffect)
 import Effect.Class.Console (log)
-import Prelude (class Show, Unit, discard, show, ($), (<<<), (<>))
+import Foreign.Object (Object)
+import Prelude (class Show, Unit, discard, show, ($), (*>), (<$>), (<<<), (<>))
 
 prettyPrintKVPair :: forall a. Show a => String -> a -> String
 prettyPrintKVPair key value = (withGraphics (foreground Blue) key) <> ": " <> show value
@@ -39,3 +44,28 @@ prettyPrintCollection (Collection record) = do
 
 colorizeError :: String -> String
 colorizeError = withGraphics (foreground Red)
+
+prettyPrintAsset :: forall m. MonadEffect m => String -> ItemAsset -> m Unit
+prettyPrintAsset assetKey (ItemAsset { _type, title, href }) =
+  let
+    titlePrefix = withGraphics (foreground Blue) (fromMaybe assetKey title) <> ": "
+
+    mediaTypeSuffix = fold $ (" (" <> _) <<< (_ <> ")") <<< show <$> _type
+  in
+    log $ titlePrefix <> href <> mediaTypeSuffix
+
+prettyPrintAssets :: forall m. MonadEffect m => Object ItemAsset -> m Unit
+prettyPrintAssets assets = void $ traverseWithIndex prettyPrintAsset assets
+
+prettyPrintItem :: forall m. MonadEffect m => Item -> m Unit
+prettyPrintItem (Item { id, stacExtensions, bbox, assets }) = do
+  log $ prettyPrintKVPair "Id" id
+  log $ prettyPrintKVPair "Extensions" stacExtensions
+  log $ prettyPrintKVPair "Bbox" bbox
+  log $ withGraphics (foreground Blue) "Assets:"
+  prettyPrintAssets assets *> log "\n"
+
+prettyPrintItems :: forall m. MonadEffect m => Array Item -> m Unit
+prettyPrintItems features = case fromArray features of
+  Just arr -> void $ traverse prettyPrintItem arr
+  Nothing -> log "No items found"

--- a/src/Types.purs
+++ b/src/Types.purs
@@ -5,6 +5,7 @@ import Data.Maybe (Maybe)
 import Data.Set (Set)
 import Data.Show.Generic (genericShow)
 import Data.String.NonEmpty (NonEmptyString)
+import Model.CollectionItemsResponse (CollectionItemsResponse)
 import Prelude (class Show)
 import Text.Parsing.Parser (Parser)
 
@@ -14,8 +15,16 @@ type RootUrl
 type CollectionId
   = String
 
+type ItemId
+  = String
+
 type CollectionContextRecord
-  = { rootUrl :: RootUrl, collectionId :: NonEmptyString, knownCollections :: Set CollectionId }
+  = { rootUrl :: RootUrl
+    , collectionId :: NonEmptyString
+    , knownCollections :: Set CollectionId
+    , itemsResponse :: CollectionItemsResponse
+    , knownItems :: Set ItemId
+    }
 
 type RootContextRecord
   = { rootUrl :: Maybe RootUrl, knownCollections :: Set CollectionId }
@@ -37,6 +46,8 @@ data Cmd
   | LocateCollection
   | SetRootUrl RootUrl
   | UnsetCollection
+  | ListItems Int
+  | NextItemsPage
 
 type StringParser
   = Parser String


### PR DESCRIPTION
## Overview

This PR adds support for listing and paging through items from a collection's context.

### Checklist

- [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

### Demo

```
stac > set root url https://franklin.nasa-hsi.azavea.com
stac https://franklin.nasa-hsi.azavea.com > set collection aviris-ng
Set context to collection aviris-ng
stac https://franklin.nasa-hsi.azavea.com > list items
Id: "aviris_ang20140530t161002"
Extensions: []
Bbox: [-115.405456,35.545716999999996,-115.38602,35.599424]
Assets:
ftp: ftp://avng_dp:P73axIvP@avng.jpl.nasa.gov/y14_data/ang20140530t161002.tar.gz ((VendorMediaType "application/gzip"))
rgb: http://avirisng.jpl.nasa.gov/aviris_locator/y14_RGB/ang20140530t161002_RGB.jpeg (JPEG)
kml_overlay: http://avirisng.jpl.nasa.gov/aviris_locator/y14_KML/ang20140530t161002_overlay_KML.kml ((VendorMediaType "application/vnd.google-earth.kml+xml"))
rgb_small: http://avirisng.jpl.nasa.gov/aviris_locator/y14_RGB/ang20140530t161002_RGB-W200.jpg (JPEG)
flight_log: http://avirisng.jpl.nasa.gov/cgi/flights_14.cgi?step=view_flightlog&flight_id=ang20140530t (HTML)
kml_outline: http://avirisng.jpl.nasa.gov/aviris_locator/y14_KML/ang20140530t161002_outline_KML.kml ((VendorMediaType "application/vnd.google-earth.kml+xml"))

...

stac https://franklin.nasa-hsi.azavea.com > next page
Got item aviris_ang20140605t182934
Extensions: []
Bbox: [-122.740551,38.547295,-122.680227,38.623188]
Assets:
ftp: ftp://avng_dp:P73axIvP@avng.jpl.nasa.gov/y14_data/ang20140605t182934.tar.gz ((VendorMediaType "application/gzip"))
rgb: http://avirisng.jpl.nasa.gov/aviris_locator/y14_RGB/ang20140605t182934_RGB.jpeg (JPEG)
kml_overlay: http://avirisng.jpl.nasa.gov/aviris_locator/y14_KML/ang20140605t182934_overlay_KML.kml ((VendorMediaType "application/vnd.google-earth.kml+xml"))
rgb_small: http://avirisng.jpl.nasa.gov/aviris_locator/y14_RGB/ang20140605t182934_RGB-W200.jpg (JPEG)
flight_log: http://avirisng.jpl.nasa.gov/cgi/flights_14.cgi?step=view_flightlog&flight_id=ang20140605t (HTML)
kml_outline: http://avirisng.jpl.nasa.gov/aviris_locator/y14_KML/ang20140605t182934_outline_KML.kml ((VendorMediaType "application/vnd.google-earth.kml+xml"))

...
```

### Notes

Can't set the page size apparently with `purescript-stac` 🤦🏻‍♂️ so I opened an issue upstream for that https://github.com/jisantuc/purescript-stac/issues/13

Closes #4 
