### PR TITLE
Show collection id in prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prompt in collection context now includes the collection id [#15](https://github.com/jisantuc/stac-repl/pull/15) (@jisantuc)
 
 ## [0.1.1] - 2021-03-22
 ### Fixed

--- a/packages.dhall
+++ b/packages.dhall
@@ -105,7 +105,7 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210318/packages.dhall sha256:98bbacd65191cef354ecbafa1610be13e183ee130491ab9c0ef6e3d606f781b5
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210409/packages.dhall sha256:e81c2f2ce790c0e0d79869d22f7a37d16caeb5bd81cfda71d46c58f6199fd33f
 
 in  upstream
   with stac =

--- a/spago.dhall
+++ b/spago.dhall
@@ -18,7 +18,7 @@ You can edit this file as you like.
   , "lists"
   , "maybe"
   , "node-readline"
-  , "ordered-ollections",
+  , "ordered-ollections"
   , "parsing"
   , "prelude"
   , "psci-support"

--- a/spago.dhall
+++ b/spago.dhall
@@ -13,12 +13,12 @@ You can edit this file as you like.
   , "control"
   , "effect"
   , "either"
-  , "foldabletraversable",
-  , "foreign-bject",
+  , "foldable-traversable"
+  , "foreign-object"
   , "lists"
   , "maybe"
   , "node-readline"
-  , "ordered-ollections"
+  , "ordered-collections"
   , "parsing"
   , "prelude"
   , "psci-support"

--- a/spago.dhall
+++ b/spago.dhall
@@ -5,15 +5,28 @@ You can edit this file as you like.
 { name = "my-project"
 , dependencies =
   [ "aff-promise"
+  , "aff"
+  , "affjax"
   , "ansi"
+  , "arrays"
   , "console"
+  , "control"
   , "effect"
-  , "monad-control"
-  , "node-process"
+  , "either"
+  , "foldabletraversable",
+  , "foreign-bject",
+  , "lists"
+  , "maybe"
   , "node-readline"
+  , "ordered-ollections",
   , "parsing"
+  , "prelude"
   , "psci-support"
+  , "refs"
   , "stac"
+  , "strings"
+  , "tuples"
+  , "unicode"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]

--- a/spago.dhall
+++ b/spago.dhall
@@ -2,7 +2,7 @@
 Welcome to a Spago project!
 You can edit this file as you like.
 -}
-{ name = "my-project"
+{ name = "stac-repl"
 , dependencies =
   [ "aff-promise"
   , "aff"


### PR DESCRIPTION
## Overview

This PR:

- shows the collection id in the prompt when in the collection context
- removes the collection id from the prompt when un-setting the collection
- adds a few convenience methods for specific prompt situations

### Checklist

* [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

### Demo

```
stac > set root url https://franklin.nasa-hsi.azavea.com
stac https://franklin.nasa-hsi.azavea.com > set collection aviris-ng
Set context to collection aviris-ng
stac https://franklin.nasa-hsi.azavea.com aviris-ng > unset collection
Returning to root context
stac https://franklin.nasa-hsi.azavea.com > 
```

## Testing Instructions

* run the demo