### PR TITLE
Upgrade purescript-stac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.2] - 2021-04-13
 ### Changed
 - Prompt in collection context now includes the collection id [#15](https://github.com/jisantuc/stac-repl/pull/15) (@jisantuc)
 
@@ -18,5 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Items and collections can be located on Mapscii maps [#12](https://github.com/jisantuc/stac-repl/pull/12) (@jisantuc)
 - Bundled repl into a container image at jisantuc/stac-repl:latest (@jisantuc)
 
-[Unreleased]: https://github.com/jisantuc/stac-repl/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/jisantuc/stac-repl/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/jisantuc/stac-repl/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/jisantuc/stac-repl/compare/v0.1.0...v0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Updated to purescript-stac 2.0 (stac spec 1.0.0-rc2) [#17](https://github.com/jisantuc/stac-repl/pull/17) (@jisantuc)
 
 ## [0.1.2] - 2021-04-13
 ### Changed

--- a/packages.dhall
+++ b/packages.dhall
@@ -122,5 +122,5 @@ in  upstream
       , "uri"
       ]
     , repo = "https://github.com/jisantuc/purescript-stac.git"
-    , version = "v1.0.1"
+    , version = "v2.0.0"
     }

--- a/spago.dhall
+++ b/spago.dhall
@@ -11,7 +11,6 @@ You can edit this file as you like.
   , "arrays"
   , "console"
   , "control"
-  , "decimals"
   , "effect"
   , "either"
   , "foldable-traversable"

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,13 +4,14 @@ You can edit this file as you like.
 -}
 { name = "stac-repl"
 , dependencies =
-  [ "aff-promise"
-  , "aff"
+  [ "aff"
+  , "aff-promise"
   , "affjax"
   , "ansi"
   , "arrays"
   , "console"
   , "control"
+  , "decimals"
   , "effect"
   , "either"
   , "foldable-traversable"

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -11,7 +11,7 @@ import Ansi.Output (foreground, withGraphics)
 import Data.Array.NonEmpty (fromArray)
 import Data.Functor (void)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses, Item(..), asset(..))
+import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses, Item(..), Asset(..))
 import Data.Traversable (fold, traverse)
 import Data.TraversableWithIndex (traverseWithIndex)
 import Effect.Class (class MonadEffect)
@@ -45,8 +45,8 @@ prettyPrintCollection (Collection record) = do
 colorizeError :: String -> String
 colorizeError = withGraphics (foreground Red)
 
-prettyPrintAsset :: forall m. MonadEffect m => String -> asset -> m Unit
-prettyPrintAsset assetKey (asset { _type, title, href }) =
+prettyPrintAsset :: forall m. MonadEffect m => String -> Asset -> m Unit
+prettyPrintAsset assetKey (Asset { _type, title, href }) =
   let
     titlePrefix = withGraphics (foreground Blue) (fromMaybe assetKey title) <> ": "
 
@@ -54,7 +54,7 @@ prettyPrintAsset assetKey (asset { _type, title, href }) =
   in
     log $ titlePrefix <> href <> mediaTypeSuffix
 
-prettyPrintAssets :: forall m. MonadEffect m => Object asset -> m Unit
+prettyPrintAssets :: forall m. MonadEffect m => Object Asset -> m Unit
 prettyPrintAssets assets = void $ traverseWithIndex prettyPrintAsset assets
 
 prettyPrintItem :: forall m. MonadEffect m => Item -> m Unit

--- a/src/Printer.purs
+++ b/src/Printer.purs
@@ -11,7 +11,7 @@ import Ansi.Output (foreground, withGraphics)
 import Data.Array.NonEmpty (fromArray)
 import Data.Functor (void)
 import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses, Item(..), ItemAsset(..))
+import Data.Stac (Collection(..), CollectionsResponse(..), ConformanceClasses, Item(..), asset(..))
 import Data.Traversable (fold, traverse)
 import Data.TraversableWithIndex (traverseWithIndex)
 import Effect.Class (class MonadEffect)
@@ -45,8 +45,8 @@ prettyPrintCollection (Collection record) = do
 colorizeError :: String -> String
 colorizeError = withGraphics (foreground Red)
 
-prettyPrintAsset :: forall m. MonadEffect m => String -> ItemAsset -> m Unit
-prettyPrintAsset assetKey (ItemAsset { _type, title, href }) =
+prettyPrintAsset :: forall m. MonadEffect m => String -> asset -> m Unit
+prettyPrintAsset assetKey (asset { _type, title, href }) =
   let
     titlePrefix = withGraphics (foreground Blue) (fromMaybe assetKey title) <> ": "
 
@@ -54,7 +54,7 @@ prettyPrintAsset assetKey (ItemAsset { _type, title, href }) =
   in
     log $ titlePrefix <> href <> mediaTypeSuffix
 
-prettyPrintAssets :: forall m. MonadEffect m => Object ItemAsset -> m Unit
+prettyPrintAssets :: forall m. MonadEffect m => Object asset -> m Unit
 prettyPrintAssets assets = void $ traverseWithIndex prettyPrintAsset assets
 
 prettyPrintItem :: forall m. MonadEffect m => Item -> m Unit

--- a/src/Repl.purs
+++ b/src/Repl.purs
@@ -234,7 +234,7 @@ execute interface ctxRef cmd = case cmd of
     ctx <- read ctxRef
     validFor toCollectionContext ctx \{ rootUrl, collectionId } ->
       launchAff_ do
-        response <- getCollectionItems rootUrl collectionId
+        response <- getCollectionItems rootUrl collectionId Nothing
         case response of
           Left err ->
             error
@@ -247,7 +247,6 @@ execute interface ctxRef cmd = case cmd of
           Right resp@{ features } -> do
             updateItemsResponse ctxRef resp
             prettyPrintItems features
-            liftEffect $ prompt interface
         liftEffect $ prompt interface
   NextItemsPage -> do
     ctx <- read ctxRef


### PR DESCRIPTION
## Overview

This PR upgrades `purescript-stac`. This has two effects -- it's now possible to add a `limit` to the request for items, which unblocks #16. It also upgrades the models to STAC spec 1.0.0-rc2, which means this could be used as a testing tool.

### Checklist

* [x] Description of PR is in an appropriate section of the [changelog](https://github.com/raster-foundry/raster-foundry/blob/develop/CHANGELOG.md) (please use [`chan`](https://github.com/geut/chan))

## Testing Instructions

* nothing new yet, just setup
